### PR TITLE
Set an appropriate SCAN_INTERVAL

### DIFF
--- a/homeassistant/components/devolo_home_network/entity_classes.py
+++ b/homeassistant/components/devolo_home_network/entity_classes.py
@@ -1,7 +1,13 @@
-"""General class for all entities."""
+"""General classes for all entities."""
+from datetime import timedelta
+
 from devolo_plc_api.device import Device
 
+from homeassistant.util import Throttle
+
 from .device import DevoloDevice
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 
 class DevoloNetworkOverviewEntity(DevoloDevice):
@@ -15,6 +21,7 @@ class DevoloNetworkOverviewEntity(DevoloDevice):
         self._name = "Connected PLC devices"
         self._unique_id = f"{self._device.serial_number}_connected_plc_devices"
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Update the value async."""
         network_overview = await self._device.plcnet.async_get_network_overview()
@@ -58,6 +65,7 @@ class DevoloWifiNetworksEntity(DevoloDevice):
         self._name = "Neighboring wifi networks"
         self._unique_id = f"{self._device.serial_number}_neighboring_wifi_networks"
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Update the value async."""
         neighbors = await self._device.device.async_get_wifi_neighbor_access_points()

--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -11,6 +11,7 @@ from .entity_classes import (
     DevoloWifiNetworksEntity,
 )
 
+PARALLEL_UPDATES = 1
 SCAN_INTERVAL = timedelta(seconds=5)
 
 
@@ -28,4 +29,4 @@ async def async_setup_entry(
     if "wifi1" in device.device.features:
         for entity in wifi_entities:
             entities.append(entity(device, entry.title))
-    async_add_entities(entities, True)
+    async_add_entities(entities)


### PR DESCRIPTION

Optimize SCAN_INTERVAL, throttle expensive updates and limit parallelism to prevent overloading the embedded device.